### PR TITLE
Use the correct field in the migration

### DIFF
--- a/db/migrate/20150212232559_add_accepted_terms_of_use_to_users.rb
+++ b/db/migrate/20150212232559_add_accepted_terms_of_use_to_users.rb
@@ -1,5 +1,5 @@
 class AddAcceptedTermsOfUseToUsers < ActiveRecord::Migration
   def change
-    add_column :users, :country, :string
+    add_column :users, :accepted_terms_of_use, :boolean
   end
 end


### PR DESCRIPTION
Schema.rb has the correct field, and the migration `add_column :users, :country, :string`already exists afterwards, which causes an error when running `rake db:migrate` 