### PR TITLE
Add locales

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,6 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
-# Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-gem 'spring',        group: :development
-
 gem 'less-rails'
 gem 'rspec',           '~> 2.14.0'
 gem 'sprockets-rails', '~> 2.0.0'
@@ -61,6 +58,9 @@ group :development do
   gem 'capistrano-rbenv'
   gem 'capistrano3-unicorn'
   gem 'sqlite3', '1.3.9'
+  # speeds up development by keeping your application running in the background.
+  # Read more: https://github.com/rails/spring
+  gem 'spring'
 end
 
 #Dashing related stuff
@@ -68,6 +68,9 @@ end
 # gem 'nokogiri'
 # gem 'htmlentities'
 
-
+group :test do
+  gem 'minitest-rails'
+  gem 'minitest-reporters'
+end
 # Use debugger
 # gem 'debugger', group: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    ansi (1.5.0)
     arbre (1.0.2)
       activesupport (>= 3.0.0)
     arel (5.0.1.20140414130214)
@@ -143,6 +144,14 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.25.1)
     minitest (5.4.2)
+    minitest-rails (2.1.1)
+      minitest (~> 5.4)
+      railties (~> 4.1)
+    minitest-reporters (1.1.9)
+      ansi
+      builder
+      minitest (>= 5.0)
+      ruby-progressbar
     multi_json (1.10.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
@@ -191,6 +200,7 @@ GEM
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.6)
+    ruby-progressbar (1.8.1)
     sass (3.2.19)
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
@@ -244,6 +254,8 @@ DEPENDENCIES
   formtastic
   jbuilder (~> 2.0)
   less-rails
+  minitest-rails
+  minitest-reporters
   pg
   puma
   rails (= 4.1.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,6 +18,17 @@ class ApplicationController < ActionController::Base
 #     session[:previous_url] = request.fullpath 
 #   end
 # end
+before_action :set_locale
+
+def set_locale
+  locale = params[:locale].try(:to_sym)
+  locale = I18n.default_locale unless I18n.available_locales.include?(locale)
+  I18n.locale = locale
+end
+
+def default_url_options(options = {})
+  { locale: I18n.locale }.merge(options)
+end
 
 def after_sign_in_path_for(resource)
   root_path

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,11 +1,10 @@
 <div class="body_devise_signup">
   <div class="signup">
 <div class="signup_title">
-  Join RefugeeWork community.
+  <%= t('users-signup.title')%>
   <br>
   <br>
-  We grow through the things we make.
-  Join the community and tell what you need or can help with!
+  <%= t('users-signup.subtitle')%>
   <br>
   <br>
 </div>

--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -1,32 +1,32 @@
 <div class="login_shared_single_link">
   <%- if controller_name != 'sessions' %>
     <br>
-    <%= link_to "Already have an account? #{I18n.t'users-links.login'}", new_session_path(resource_name) %><br />
+    <%= link_to "#{t('users-links.already-account')} #{t('users-links.login')}", new_session_path(resource_name) %><br />
   <% end -%>
 </div>
 <div class="login_shared_single_link">
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
     <br>
-    <%= link_to "Not registered yet? #{I18n.t'users-links.signup'}", new_registration_path(resource_name) %><br />
+    <%= link_to "Not registered yet? #{t('users-links.signup')}", new_registration_path(resource_name) %><br />
   <% end -%>
 </div>
 
 <div class="login_shared_single_link">
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
     <br>
-    <%= link_to "#{I18n.t'users-links.forgot-password'}", new_password_path(resource_name) %><br />
+    <%= link_to "#{t('users-links.forgot-password')}", new_password_path(resource_name) %><br />
   <% end -%>
 </div>
 
 <div class="login_shared_single_link">
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-    <%= link_to "#{I18n.t'users-links.confirmation-instructions'}", new_confirmation_path(resource_name) %><br />
+    <%= link_to "#{t('users-links.confirmation-instructions')}", new_confirmation_path(resource_name) %><br />
   <% end -%>
 </div>
 
 <div class="login_shared_single_link">
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-    <%= link_to "#{I18n.t'users-links.unlock-instructions'}", new_unlock_path(resource_name) %><br />
+    <%= link_to "#{t('users-links.unlock-instructions')}", new_unlock_path(resource_name) %><br />
   <% end -%>
 </div>
 

--- a/app/views/static_pages/welcome.html.erb
+++ b/app/views/static_pages/welcome.html.erb
@@ -1,25 +1,25 @@
 <div class="body_welcome">
   <div class="leads_index_no_leads_available">
-    Welcome to REFUGEES WORK
+    <%= t('.title') %>
     <br>
     <br>
-    We help newcomers and locals to work together. Local organisations can help newcomers start their business, offer them volunteering opportunities or hire them as freelancers. <%= link_to "Read more...", info_path %>
+    <%= t('.description') %> <%= link_to t('.read_more'), info_path %>
     <br>
     <br>
     <br>
     <div class="leads_index_no_leads_available_button_third">
-      <%= link_to "BROWSE THE OFFERS", leads_path %>
+      <%= link_to t('.browse_offers'), leads_path %>
     </div>
     <br>
     <br>
     <br>
-    <i class="fa fa-key"> Freelancing</i>
-    &nbsp &nbsp <i class="fa fa-cubes"> Starting a business</i>
-    &nbsp &nbsp <i class="fa fa-pencil"> B2B</i>
-    &nbsp &nbsp <i class="fa fa-users"> Co-founding</i>
-    &nbsp &nbsp <i class="fa fa-comments-o"> Collaboration</i>
-    &nbsp &nbsp <i class="fa fa-heart-o"> Volunteering</i>
-    &nbsp &nbsp <i class="fa fa-book"> Learning</i>
+    <i class="fa fa-key"> <%= t('.freelancing') %></i>
+    &nbsp &nbsp <i class="fa fa-cubes"> <%= t('.start_business') %> </i>
+    &nbsp &nbsp <i class="fa fa-pencil"> <%= t('.b2b') %> </i>
+    &nbsp &nbsp <i class="fa fa-users"> <%= t('.cofounding') %> </i>
+    &nbsp &nbsp <i class="fa fa-comments-o"> <%= t('.collaboration') %> </i>
+    &nbsp &nbsp <i class="fa fa-heart-o"> <%= t('.volunteering') %> </i>
+    &nbsp &nbsp <i class="fa fa-book"> <%= t('.learning') %> </i>
     <br>
     <br>
     <br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,7 @@ module LeadShareApp
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     config.i18n.default_locale = :en
+    config.i18n.available_locales = [:en, :es]
 
     #config.assets.initialize_on_precompile = false
     config.assets.paths << "{Rails.root}/app/assets/components"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,8 @@ en:
     password: "Password"
     minimal-char: "characters minimum"
     password-confirmation: "Password confirmation"
+    title: Join RefugeeWork community.
+    subtitle: We grow through the things we make. Join the community and tell what you need or can help with!
 
 #Login
   users-login:
@@ -84,11 +86,7 @@ en:
     confirmation-instructions: "Didn't receive confirmation instructions?"
     unlock-instructions: "Didn't receive unlock instructions?"
     sign-in-with: "Sign in with"
-
-
-
-
-
+    already-account: Already have an account?
 
 # ############################################################################################
 # Page 1 - LEADS/INDEX (root page)

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,19 @@
+es:
+  users-signup:
+    signup: Registrarte
+    email: Email
+    password: Contraseña
+    minimal-char: carácteres como mínimo
+    password-confirmation: Confirma tu contraseña
+    title: Únete a la comunidad de RefugeeWork.
+    subtitle: Crecemos a través de las cosas que hacemos. ¡Únete a la comunindad y di que necesitas o en que puedes ayudar!
+
+  users-links:
+    login: Entrar
+    signup: Regístrate
+    send-password-instructions: Resetear contraseña
+    forgot-password: ¿Has olvidado tu contraseña?
+    confirmation-instructions: ¿No recibiste instrucciones de confirmación?
+    unlock-instructions: ¿No recibiste instrucciones de desbloqueo?
+    sign-in-with: Entrar con
+    already-account: ¿Ya tienes una cuenta?

--- a/config/locales/static_pages.yml
+++ b/config/locales/static_pages.yml
@@ -1,0 +1,32 @@
+en:
+  menu:
+    languages:
+      es: Spanish
+      en: English
+  static_pages:
+    welcome:
+      b2b: B2B
+      browse_offers: BROWSE THE OFFERS
+      cofounding: Co-founding
+      collaboration: Collaboration
+      description: We help newcomers and locals to work together. Local organisations can help newcomers start their business, offer them volunteering opportunities or hire them as freelancers.
+      freelancing: Freelancing
+      learning: Learning
+      read_more: Read more...
+      start_business: Starting a business
+      title: Welcome to REFUGEES WORK
+      volunteering: Volunteering
+es:
+  static_pages:
+    welcome:
+      b2b: B2B
+      browse_offers: VER OFERTAS
+      cofounding: Cofundar
+      collaboration: Colaboración
+      description: Ayudamos a recién llegados y locales a trabajar juntos. Organizaciones locales pueden ayudar a recién llegados a empezar su negocio, ofrecerles oportunidades de voluntariado o contratarlos como autónomos.
+      freelancing: Autónomos
+      learning: Aprender
+      read_more: Leer más...
+      start_business: Empezar un negocio
+      title: Bienvenido a REFUGEES WORK
+      volunteering: Voluntariado

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,23 +1,24 @@
 Rails.application.routes.draw do
-  devise_for :admin_users, ActiveAdmin::Devise.config
-  ActiveAdmin.routes(self)
-  devise_for :users, controllers: {registrations: 'registrations'}
+  scope '(:locale)' do
+    devise_for :admin_users, ActiveAdmin::Devise.config
+    ActiveAdmin.routes(self)
+    devise_for :users, controllers: {registrations: 'registrations'}
 
-  resources :users do
-    match '/users/:id/edit',            to: 'users#edit',       via: 'edit'
+    resources :users do
+      match '/users/:id/edit',            to: 'users#edit',       via: 'edit'
+    end
+
+    resources :leads
+      get 'leads/show'
+      get 'leads/new'
+      #get 'leads/edit' TODO: Enable users to edit their posts
+
+    resources :orders
+      get '/address_book'                 => 'orders#address_book'
+
+    resources :static_pages
+      root 'static_pages#welcome'
+      get '/info'                         => 'static_pages#info'
+      get '/new_lead_confirmation'        => 'static_pages#new_lead_confirmation'
   end
-
-  resources :leads
-    get 'leads/show'
-    get 'leads/new'
-    #get 'leads/edit' TODO: Enable users to edit their posts
-
-  resources :orders
-    get '/address_book'                 => 'orders#address_book'
-
-  resources :static_pages
-    root 'static_pages#welcome'
-    get '/info'                         => 'static_pages#info'
-    get '/new_lead_confirmation'        => 'static_pages#new_lead_confirmation'
-
-  end
+end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+ApplicationController.class_eval do
+  def any_action
+    render nothing: true
+  end
+end
+
+Rails.application.routes.draw do
+  get 'any_action' => 'application#any_action'
+end
+
+class ApplicationControllerTest < ActionController::TestCase
+  test 'it falls back to english without a locale' do
+    get :any_action
+    assert_response :success
+    assert_equal 'Welcome to REFUGEES WORK', I18n.t('static_pages.welcome.title')
+  end
+
+  test 'the passed locale is used for translation' do
+    get :any_action, locale: 'es'
+    assert_response :success
+    assert_equal 'Bienvenido a REFUGEES WORK', I18n.t('static_pages.welcome.title')
+  end
+
+  test 'locale is mantained between requests' do
+    skip('Not implemented due to https://github.com/rspec/rspec-rails/issues/255')
+  end
+
+  test 'if the locale does not exist it falls back to english' do
+    get :any_action, locale: 'ru'
+    assert_response :success
+    assert_equal 'Welcome to REFUGEES WORK', I18n.t('static_pages.welcome.title')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
+require 'minitest/rails'
+require 'minitest/reporters'
 
-class ActiveSupport::TestCase
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  #
-  # Note: You'll currently still have to declare fixtures explicitly in integration tests
-  # -- they do not yet inherit this setting
-  fixtures :all
-
-  # Add more helper methods to be used by all tests here...
-end
+Minitest::Reporters.use!


### PR DESCRIPTION
This is just a brief setup, not the translations.
- If you go to /, english is shown
- Same if you go to /en
- If you go to /es, Spanish translation is shown (the one I added, we can just remove it and use german)
- The locale is kept between requests (thanks to `ApplicationController#default_url_options` and `ApplicationController#before_action`. You can give it a try by going to Register/Login from the root page.

There is no frontend and just a few translations added. I didn't add it because it takes a lot of time, and if the frontend will be changed soon, there's not a lot of value translating the views at the moment.

Also added a test
