### PR TITLE
Add email confirmation & alert components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development do
   # speeds up development by keeping your application running in the background.
   # Read more: https://github.com/rails/spring
   gem 'spring'
+  gem "letter_opener"
 end
 
 #Dashing related stuff

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
     arbre (1.0.2)
       activesupport (>= 3.0.0)
@@ -138,11 +140,15 @@ GEM
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     less (2.5.1)
       commonjs (~> 0.2.7)
     less-rails (2.5.0)
       actionpack (>= 3.1)
       less (~> 2.5.0)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     libv8 (3.16.14.5)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -166,6 +172,7 @@ GEM
     polyamorous (1.1.0)
       activerecord (>= 3.0)
     polyglot (0.3.5)
+    public_suffix (3.1.1)
     puma (2.9.1)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
@@ -260,6 +267,7 @@ DEPENDENCIES
   formtastic
   jbuilder (~> 2.0)
   less-rails
+  letter_opener
   minitest-rails
   minitest-reporters
   pg (~> 0.18.4)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,8 @@
 //= require turbolinks
 //= require_tree .
 
+$(document).ready(function(){
+    $(".close-alert").click(function(){
+        $(this).closest("div").remove();
+    });
+});

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,3 +14,46 @@
  *= require_self
  *= require font-awesome
  */
+
+.alert {
+    margin-top: -1.1rem;
+    padding-top: 1rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    font-family: Helvetica, "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", メイリオ, Meiryo, "ＭＳ Ｐゴシック", sans-serif;
+    padding-bottom: 1rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+.alert.alert-info {
+    color: #004085;
+    background-color: #cce5ff;
+    border-color: #b8daff;
+}
+
+.alert.alert-success {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+}
+
+.alert.alert-danger {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+}
+
+.alert.alert-warning {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+}
+
+.close-alert {
+    float: right;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,10 @@
 module ApplicationHelper
+    def flash_class(level)
+        case level
+            when "notice"  then "alert alert-info"
+            when "success" then "alert alert-success"
+            when "error"   then "alert alert-danger"
+            when "alert"   then "alert alert-warning"
+        end
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ActiveRecord::Base
   # validates_format_of :tracking_id, with: /\A[a-zA-Z0-9\s\-_]+\z/, :on => :update, presence: false
 
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   has_many :orders, foreign_key: "selector_id"
   has_many :selected_leads, through: :orders, source: :selected

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,7 +68,7 @@
   <a id="top" name="top"> &nbsp; </a>
 
   <%= render 'layouts/top_menu' %>
-
+  <%= render "shared/notice_and_alert" %>
   <%= yield %>
 
   <%= render 'layouts/footer' %>

--- a/app/views/shared/_alert_close_button.html.erb
+++ b/app/views/shared/_alert_close_button.html.erb
@@ -1,0 +1,3 @@
+<button class="close-alert">
+    <span>x</span>
+</button>

--- a/app/views/shared/_notice_and_alert.html.erb
+++ b/app/views/shared/_notice_and_alert.html.erb
@@ -1,0 +1,21 @@
+<!-- Flash -->
+<br>
+
+<% flash.each do |key, value| %>
+    <% if key == "errors" %>
+        <div class="alert alert-danger">
+            <ul class="errors-list">
+                <% value.each do |val| %>
+                    <li><%= val %></li>
+                <% end %>
+            </ul>
+            <%= render "shared/alert_close_button" %>
+        </div>
+    <% else %>
+        <div class="<%= flash_class(key) %>">
+            <%= value %>
+            <%= render "shared/alert_close_button" %>
+        </div>
+    <% end %>
+<% end %>
+<!-- end flash -->

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener # :smtp
 
   config.action_mailer.smtp_settings = {
     address:              'smtp.mailgun.org',

--- a/db/migrate/20190830155457_add_confirmable_to_users.rb
+++ b/db/migrate/20190830155457_add_confirmable_to_users.rb
@@ -1,0 +1,23 @@
+class AddConfirmableToUsers < ActiveRecord::Migration
+  # Note: You can't use change, as User.update_all will fail in the down migration
+  def up
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+    add_column :users, :unconfirmed_email, :string # Only if using reconfirmable
+    add_index :users, :confirmation_token, unique: true
+    
+    # User.reset_column_information # Need for some types of updates, but not for update_all.
+    # http://dominicwong617.github.io/ruby/rails/2014/11/20/reset-column-information/
+
+    # To avoid a short time window between running the migration and updating all existing
+    # users as confirmed, do the following
+    User.update_all confirmed_at: DateTime.now
+    # All existing user accounts should be able to log in after this.
+  end
+
+  def down
+    remove_columns :users, :confirmation_token, :confirmed_at, :confirmation_sent_at
+    remove_columns :users, :unconfirmed_email # Only if using reconfirmable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160624231305) do
+ActiveRecord::Schema.define(version: 20190830155457) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "namespace"
@@ -106,8 +106,13 @@ ActiveRecord::Schema.define(version: 20160624231305) do
     t.string   "languages"
     t.boolean  "subscribed_to_notifications", default: true
     t.string   "user_type"
+    t.string   "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string   "unconfirmed_email"
   end
 
+  add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
   add_index "users", ["email"], name: "index_users_on_email", unique: true
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 


### PR DESCRIPTION
To reduce tons of fake accounts signing up and filling the database, this is my low hanging fruit proposal — ask users to confirm their email address. If they didn't, they couldn't sign in and proceed with the other steps.

This is not the silver bullet to fight spams, but this can help minimize it. On infrastructure level, you also could implement DDoS protection, botnet protection and etc. CloudFlare is offering these features for free.

Back to this main topic, included below are some screenshots from this feature implementation. The alert components was not meant for this PR. But, I included them here for completeness because they kinda need each other.

#### After sign up
![1-after-sign-up](https://user-images.githubusercontent.com/3416976/64040453-a6c1ee80-cb8f-11e9-94c0-8ca653ec5a27.jpg)

#### If user tries to sign in without confirming the email
![2-force-confirm](https://user-images.githubusercontent.com/3416976/64040454-a6c1ee80-cb8f-11e9-87e5-639ff68dae69.jpg)

#### After sign in
![3-sign-in-ok](https://user-images.githubusercontent.com/3416976/64040455-a6c1ee80-cb8f-11e9-9cc7-653363f9806b.jpg)

#### After sign out
![4-signed-out](https://user-images.githubusercontent.com/3416976/64040457-a75a8500-cb8f-11e9-93e7-3be3b5b54ccf.jpg)

#### After user clicked on the confirmation link
![5-after-clicking-confirmation-link](https://user-images.githubusercontent.com/3416976/64040458-a75a8500-cb8f-11e9-9ab5-ca9508571ec8.jpg)

#### The confirmation email
![6-confirmation-email](https://user-images.githubusercontent.com/3416976/64040460-a75a8500-cb8f-11e9-9268-061336888802.png)
