### PR TITLE
Add www to mailer config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
     enable_starttls_auto: true  }
 
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.default_url_options = { :host => 'http://refugeeswork.com' }
+  config.action_mailer.default_url_options = { :host => 'http://www.refugeeswork.com' }
   # Code is not reloaded between requests.
   config.cache_classes = true
 


### PR DESCRIPTION
Sorry for the late action @ninabreznik. It took me a while to debug and figure out what was the main issue. In fact, I tried to run the whole setup locally in production mode and everything seems worked fine. 

I also checked Devise source code for the version that app is using and nothing weird found. After a while, I realized that the confirmation email link is not using the final URL for the Rails app.

The confirmation email link is using `refugeeswork.com` while the final URL of the app is actually `www.refugeeswork.com`. 

The web server that you are using (not sure how you configured it) is not passing the parameters along when doing redirection. It just redirects `refugeeswork.com/some/params` to `www.refugeeswork.com` without carrying the params over.

When the request hits the server, it thinks the client wants to visit the root path. The confirmation path didn't get hit, which resulted to the `confirmed_at` field in `users` table never gets updated and stops you from log-in.

![carbon](https://user-images.githubusercontent.com/3416976/64098330-31296e80-cd99-11e9-8f5e-4c18007cb55c.png)

This PR should fix this problem. All Devise-mailers should now use `www.refugeeswork.com` instead of `refugeeswork.com` to avoid the redirection.

Moving forward, I strongly suggest you to find and replace all `refugeeswork.com` instances to `www.refugeeswork.com` in the source code.
